### PR TITLE
Properly handle keyframes blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ function parseRules (base, sprites, options, complete) {
     // you can sometimes exceed the callstack limit
     process.nextTick(function () {
 
-      // skip font-face declarations
-      if (rule.selectors[0] && rule.selectors[0] == '@font-face') {
+      // skip keyframes and font-face declarations
+      if (rule.keyframes || (rule.selectors[0] && rule.selectors[0] == '@font-face')) {
         return nextRule(rule)
       }
 

--- a/test/css/multi.css
+++ b/test/css/multi.css
@@ -32,3 +32,13 @@
 .bar {
   background-image: url('../img/a.png');
 }
+
+@keyframes animate {
+  from {
+    top: 0;
+  }
+
+  to {
+    top: 100px;
+  }
+}

--- a/test/expected/multi-base.css
+++ b/test/expected/multi-base.css
@@ -23,3 +23,13 @@
 .mdo {
   width: 50px
 }
+
+@keyframes animate {
+  from {
+    top: 0
+  }
+
+  to {
+    top: 100px
+  }
+}


### PR DESCRIPTION
Hello @fat, @dpup,

`@keyframes` objects don't have the `selectors` property, which was causing sus to die whenever it encountered a `@keyframes` declaration.

Please review the following commits I made in branch 'koop-keyframes'.

170d513b4ba2f9b87cbfbc3d5cdb4c566152bf21 (2013-03-12 15:38:43 -0700)
Skip keyframes blocks.

R=@fat
R=@dpup
